### PR TITLE
added command line option to report small files with high similarity…

### DIFF
--- a/Duplo.h
+++ b/Duplo.h
@@ -33,6 +33,7 @@ class Duplo {
 protected:
     std::string m_listFileName;
     unsigned int m_minBlockSize;
+    unsigned int m_blockPercentThreshold;
     unsigned int m_minChars;
     bool m_ignorePrepStuff;
     bool m_ignoreSameFilename;
@@ -42,14 +43,19 @@ protected:
     unsigned char* m_pMatrix;
 
     void reportSeq(int line1, int line2, int count, SourceFile* pSource1, SourceFile* pSource2, std::ostream& outFile);
-	int process(SourceFile* pSource1, SourceFile* pSource2, std::ostream& outFile);
+    int process(SourceFile* pSource1, SourceFile* pSource2, std::ostream& outFile);
 
     const std::string getFilenamePart(const std::string& fullpath) const;
     bool isSameFilename(const std::string& filename1, const std::string& filename2) const;
 
 public:
-    Duplo(const std::string& listFileName, unsigned int minBlockSize, unsigned int minChars, bool ignorePrepStuff, bool ignoreSameFilename, bool Xml);
-	~Duplo();
+    Duplo(
+        const std::string& listFileName,     
+        unsigned int blockPercentThreshold, 
+        unsigned int minBlockSize, 
+        unsigned int minChars, 
+        bool ignorePrepStuff, bool ignoreSameFilename, bool Xml);
+    ~Duplo();
     void run(std::string outputFileName);
 };
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 CC = g++
 
 # Flags
-CXXFLAGS = -O3
+CXXFLAGS = -O3 -Wall
 LDFLAGS =  ${CXXFLAGS}
 
 # Define what extensions we use

--- a/SourceFile.cpp
+++ b/SourceFile.cpp
@@ -24,17 +24,17 @@
 
 SourceFile::SourceFile(const std::string& fileName, const unsigned int minChars, const bool ignorePrepStuff) :
     m_fileName(fileName),
-    m_minChars(minChars),
-    m_ignorePrepStuff(ignorePrepStuff),
-    m_FileType(FileType::GetFileType(fileName))
+    m_FileType(FileType::GetFileType(fileName)),
+    m_minChars(minChars),    
+    m_ignorePrepStuff(ignorePrepStuff)
 {
-	TextFile listOfFiles(m_fileName.c_str());
+    TextFile listOfFiles(m_fileName.c_str());
 
     std::vector<std::string> lines;
     listOfFiles.readLines(lines, false);
-	
+    
     int openBlockComments = 0;
-	for(int i=0;i<(int)lines.size();i++){
+    for(int i=0;i<(int)lines.size();i++){
         std::string& line = lines[i];
         std::string tmp;
 
@@ -67,19 +67,19 @@ SourceFile::SourceFile(const std::string& fileName, const unsigned int minChars,
             tmp = line;
         }
 
-		std::string cleaned;
-		getCleanLine(tmp, cleaned);
-		
-		if(isSourceLine(cleaned)){
-			m_sourceLines.push_back(new SourceLine(cleaned, i));
-		}
-	}
+        std::string cleaned;
+        getCleanLine(tmp, cleaned);
+        
+        if(isSourceLine(cleaned)){
+            m_sourceLines.push_back(new SourceLine(cleaned, i));
+        }
+    }
 }
 
 void SourceFile::getCleanLine(const std::string& line, std::string& cleanedLine){
     // Remove single line comments
     cleanedLine.reserve(line.size());
-	int lineSize = (int)line.size();
+    int lineSize = (int)line.size();
     for(int i=0;i<(int)line.size();i++){
         switch (m_FileType)
         {
@@ -99,6 +99,10 @@ void SourceFile::getCleanLine(const std::string& line, std::string& cleanedLine)
                 if(i < lineSize-1 && line[i] == '\''){
                     return;
                 }
+                break;
+            
+            // no pre-processing of code of unknown languages
+            case FileType::FILETYPE_UNKNOWN:
                 break;
         }
         cleanedLine.push_back(line[i]);
@@ -160,6 +164,11 @@ bool SourceFile::isSourceLine(const std::string& line){
              return std::string::npos == tmp.find(PreProc_VB.c_str(), 0, PreProc_VB.length());
           }
           break;
+          
+        // no pre-processing of code of unknown languages
+        case FileType::FILETYPE_UNKNOWN:
+            break;
+          
        }
     }
 
@@ -171,15 +180,15 @@ bool SourceFile::isSourceLine(const std::string& line){
 }
 
 int SourceFile::getNumOfLines(){
-	return (int)m_sourceLines.size();
+    return (int)m_sourceLines.size();
 }
 
 SourceLine* SourceFile::getLine(const int index){
-	return m_sourceLines[index];
+    return m_sourceLines[index];
 }
 
 const std::string& SourceFile::getFilename() const {
-	return m_fileName;
+    return m_fileName;
 }
 
 bool SourceFile::operator==(const SourceFile &other) const {


### PR DESCRIPTION
… fixed warnings (-Wall), and fix mixed tabs+spaces in touched files.

The change helps identify small whole-file duplications, such as you get with creation of small utility classes by multiple programmers on big code basses in OOP languages.