### PR TITLE
just a minor change to make the output easier to sort

### DIFF
--- a/Duplo.cpp
+++ b/Duplo.cpp
@@ -275,9 +275,9 @@ void Duplo::run(std::string outputFileName){
         }
 
         if(blocks > 0){
-            std::cout << " found " << blocks << " block(s)" << std::endl;
+            std::cout << " found: " << blocks << " block(s)" << std::endl;
         } else {
-            std::cout << " nothing found" << std::endl;
+            std::cout << " nothing found." << std::endl;
         }
 
         blocksTotal+=blocks;


### PR DESCRIPTION
Putting a colon in the "found: %i blocks" and a full stop after "nothing found." just makes command line manipulation of the output with unix tools a little easier. :)