### PR TITLE
added -cll option to allow user passing files through command line

### DIFF
--- a/ArgumentParser.cpp
+++ b/ArgumentParser.cpp
@@ -3,12 +3,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -48,8 +48,17 @@ int ArgumentParser::getInt(const char *s, int defaultValue){
             return atoi(argv[i+1]);
         }
     }
-    
+
     return defaultValue;
+}
+
+void ArgumentParser::getFileNames( Duplo & duplo ) const {
+    for ( int i = 1; i < argc - 1; i++ ) {
+        std::ifstream f( argv[i] );
+        if ( f.good() )
+            duplo.pushFileName( argv[i] );
+        f.close();
+    }
 }
 
 float ArgumentParser::getFloat(const char *s, float defaultValue){
@@ -58,6 +67,6 @@ float ArgumentParser::getFloat(const char *s, float defaultValue){
             return (float)atof(argv[i+1]);
         }
     }
-    
+
     return defaultValue;
 }

--- a/ArgumentParser.cpp
+++ b/ArgumentParser.cpp
@@ -56,6 +56,7 @@ int ArgumentParser::getInt(const char *s, int defaultValue){
     return defaultValue;
 }
 
+#ifdef _WIN32
 void ArgumentParser::winGlob( Duplo & duplo, const std::string & path ) const
 {
 	intptr_t handle;
@@ -70,7 +71,9 @@ void ArgumentParser::winGlob( Duplo & duplo, const std::string & path ) const
 	while ( _findnext(handle, &fileinfo) == 0 )
 		duplo.pushFileName(fileinfo.name);
 	_findclose( handle );
+
 }
+#endif
 
 void ArgumentParser::getFileNames( Duplo & duplo ) const {
     for ( int i = 1; i < argc - 1; i++ ) {

--- a/ArgumentParser.h
+++ b/ArgumentParser.h
@@ -30,6 +30,8 @@ private:
     int argc;
     const char **argv;
 
+	void ArgumentParser::winGlob( Duplo & duplo, const std::string & path ) const;
+
 public:
     ArgumentParser(int m_argc, const char* m_argv[]);
 

--- a/ArgumentParser.h
+++ b/ArgumentParser.h
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -21,6 +21,9 @@
 
 #ifndef _ARGUMENTPARSER_H_
 #define _ARGUMENTPARSER_H_
+
+#include <fstream>
+#include "Duplo.h"
 
 class ArgumentParser{
 private:
@@ -34,6 +37,7 @@ public:
     const char *getStr(const char *s, const char *defaultValue="");
     int getInt(const char *s, int defaultValue);
     float getFloat(const char *s, float defaultValue);
+    void  getFileNames( Duplo & duplo ) const;
 };
 
 #endif

--- a/ArgumentParser.h
+++ b/ArgumentParser.h
@@ -30,7 +30,9 @@ private:
     int argc;
     const char **argv;
 
-	void ArgumentParser::winGlob( Duplo & duplo, const std::string & path ) const;
+#ifdef _WIN32
+    void winGlob( Duplo & duplo, const std::string & path ) const;
+#endif
 
 public:
     ArgumentParser(int m_argc, const char* m_argv[]);

--- a/Duplo.cpp
+++ b/Duplo.cpp
@@ -349,9 +349,12 @@ int main(int argc, const char* argv[]){
             ap.getInt("-mc", MIN_CHARS),
             ap.is("-ip"), ap.is("-d"), ap.is("-xml")
         );
-        if ( ap.is("-cll") )
-            ap.getFileNames( duplo );
-        duplo.run(argv[argc-1]);
+		if (ap.is("-cll")) {
+			ap.getFileNames(duplo);
+			duplo.run("duplo.out");
+		}
+		else
+			duplo.run(argv[argc - 1]);
     } else {
         std::cout << "\nNAME\n";
         std::cout << "       Duplo " << VERSION << " - duplicate source code block finder\n\n";
@@ -383,6 +386,5 @@ int main(int argc, const char* argv[]){
         std::cout << "       Christian M. Ammann (cammann@giants.ch)\n";
         std::cout << "       Trevor D'Arcy-Evans (tdarcyevans@hotmail.com)\n\n";
     }
-
     return 0;
 }

--- a/Duplo.h
+++ b/Duplo.h
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <iostream>
+#include <vector>
 
 class SourceFile;
 
@@ -32,6 +33,7 @@ const std::string VERSION = "0.2.0";
 class Duplo {
 protected:
     std::string m_listFileName;
+    std::vector<std::string> m_fileNames;
     unsigned int m_minBlockSize;
     unsigned int m_blockPercentThreshold;
     unsigned int m_minChars;
@@ -50,14 +52,14 @@ protected:
 
 public:
     Duplo(
-        const std::string& listFileName,     
-        unsigned int blockPercentThreshold, 
-        unsigned int minBlockSize, 
-        unsigned int minChars, 
+        const std::string& listFileName,
+        unsigned int blockPercentThreshold,
+        unsigned int minBlockSize,
+        unsigned int minChars,
         bool ignorePrepStuff, bool ignoreSameFilename, bool Xml);
     ~Duplo();
     void run(std::string outputFileName);
+    void pushFileName( const std::string & path );
 };
 
 #endif
-

--- a/Duplo.vcxproj
+++ b/Duplo.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -18,12 +18,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
I've added a very basic support to select files from command line, I didn't wanted to modify the program structure a lot so I've just added a `-cll` option that will specify Duplo not to take the SourceFiles list from a file, but instead from the command line. Here is a usage example :
`./duplo -cll xxx.h *.cpp out.list`
There would be better ways to handle this but still, it is working !