### PR TITLE
Recognize *.cc files as C++ by default

### DIFF
--- a/src/FileTypeFactory.cpp
+++ b/src/FileTypeFactory.cpp
@@ -16,7 +16,7 @@ IFileTypePtr FileTypeFactory::CreateFileType(
     unsigned minChars) {
     auto ext = StringUtil::ToLower(StringUtil::GetFileExtension(filename));
     IFileTypePtr fileType;
-    if (ext == "c" || ext == "cpp" || ext == "cxx" || ext == "h")
+    if (ext == "c" || ext == "cpp" || ext == "cxx" || ext == "h" || ext == "cc")
         fileType.reset(new FileType_C(ignorePrepStuff, minChars));
     else if (ext == "cs")
         fileType.reset(new FileType_CS(ignorePrepStuff, minChars));


### PR DESCRIPTION
Both GCC and Clang recognize .cc files as
being written in C++.