### PR TITLE
Fixes and improvements for MSVC, add Windows builds to CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,9 +24,9 @@ jobs:
       run: |
         echo ${{ steps.tag.outputs.new_tag }} > tag.txt
     - name: upload new tag artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: uploads
+        name: tag-txt
         path: tag.txt
   build-linux:
     runs-on: ubuntu-latest
@@ -34,9 +34,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: download artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
-        name: uploads
+        name: tag-txt
+        path: uploads
 
     - uses: actions/setup-node@v4
       with:
@@ -48,14 +49,14 @@ jobs:
         export DUPLO_VERSION=`cat ./uploads/tag.txt`
         mkdir -p build
         pushd build
-        cmake .. -DDUPLO_VERSION=\"$DUPLO_VERSION\"
+        cmake .. -DDUPLO_VERSION=\"$DUPLO_VERSION\" -DCMAKE_BUILD_TYPE=Release
         make
         popd
         zip --junk-paths duplo-linux build/duplo
     - name: upload linux artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: uploads
+        name: linux-build
         path: duplo-linux.zip
   build-macos:
     runs-on: macos-latest
@@ -63,32 +64,58 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: download artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
-        name: uploads
+        name: tag-txt
+        path: uploads
     - name: build
       run: |
         brew install bats-core
         export DUPLO_VERSION=`cat ./uploads/tag.txt`
         mkdir -p build
         pushd build
-        cmake .. -DDUPLO_VERSION=\"$DUPLO_VERSION\"
+        cmake .. -DDUPLO_VERSION=\"$DUPLO_VERSION\" -DCMAKE_BUILD_TYPE=Release
         make
         popd
         zip --junk-paths duplo-macos build/duplo
     - name: upload macos artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: uploads
+        name: macos-build
         path: duplo-macos.zip
+  build-windows:
+    runs-on: windows-latest
+    needs: [bump-tag-dry]
+    steps:
+    - uses: actions/checkout@v4
+    - name: download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: tag-txt
+        path: uploads
+    - name: build
+      run: |
+        $duploVersion = Get-Content .\uploads\tag.txt
+        mkdir build | Out-Null
+        pushd build
+        cmake .. "-DDUPLO_VERSION=`"$duploVersion`"" -G "Visual Studio 17 2022" -A x64
+        cmake --build . --config Release
+        popd
+        Compress-Archive -Path build\Release\duplo.exe -DestinationPath duplo-windows.zip
+    - name: upload windows artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-build
+        path: duplo-windows.zip
   push-docker-image:
     runs-on: ubuntu-latest
     needs: [bump-tag-dry]
     steps:
     - name: download artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
-        name: uploads
+        name: tag-txt
+        path: uploads
 
     - name: set version
       id: version
@@ -133,7 +160,7 @@ jobs:
   upload-release:
     if: success()
     runs-on: ubuntu-latest
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-macos, build-windows]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -156,9 +183,9 @@ jobs:
         draft: false
         prerelease: false
     - name: download artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
-        name: uploads
+        path: uploads
     - name: upload macos
       id: upload-macos
       uses: actions/upload-release-asset@v1.0.1
@@ -166,7 +193,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./uploads/duplo-macos.zip
+        asset_path: ./uploads/macos-build/duplo-macos.zip
         asset_name: duplo-macos.zip
         asset_content_type: application/zip
     - name: upload linux
@@ -176,6 +203,17 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./uploads/duplo-linux.zip
+        asset_path: ./uploads/linux-build/duplo-linux.zip
         asset_name: duplo-linux.zip
         asset_content_type: application/zip
+    - name: upload windows
+      id: upload-windows
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./uploads/windows-build/duplo-windows.zip
+        asset_name: duplo-windows.zip
+        asset_content_type: application/zip
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,17 @@ file(GLOB SOURCES src/*.cpp)
 
 SET(DUPLO_VERSION "\"v1.0.1\"" CACHE STRING "Duplo version")
 
-if(MSVC)
-else()
-    add_compile_options(-O3 -Wall -Werror -std=c++17)
-    add_compile_definitions(DUPLO_VERSION=${DUPLO_VERSION})
-endif()
 add_executable(duplo ${SOURCES})
+
+set_target_properties(duplo PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_compile_definitions(duplo PRIVATE DUPLO_VERSION=${DUPLO_VERSION})
+
+if(NOT MSVC)
+    target_compile_options(duplo PRIVATE -Wall -Werror)
+endif()
+
+

--- a/Duplo.vcxproj
+++ b/Duplo.vcxproj
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Duplo.vcxproj
+++ b/Duplo.vcxproj
@@ -108,8 +108,10 @@
     <ClCompile Include="src\Duplo.cpp" />
     <ClCompile Include="src\FileTypeBase.cpp" />
     <ClCompile Include="src\FileTypeFactory.cpp" />
+    <ClCompile Include="src\FileType_Ada.cpp" />
     <ClCompile Include="src\FileType_C.cpp" />
     <ClCompile Include="src\FileType_CS.cpp" />
+    <ClCompile Include="src\FileType_Java.cpp" />
     <ClCompile Include="src\FileType_S.cpp" />
     <ClCompile Include="src\FileType_Unknown.cpp" />
     <ClCompile Include="src\FileType_VB.cpp" />
@@ -129,8 +131,10 @@
     <ClInclude Include="src\Duplo.h" />
     <ClInclude Include="src\FileTypeBase.h" />
     <ClInclude Include="src\FileTypeFactory.h" />
+    <ClInclude Include="src\FileType_Ada.h" />
     <ClInclude Include="src\FileType_C.h" />
     <ClInclude Include="src\FileType_CS.h" />
+    <ClInclude Include="src\FileType_Java.h" />
     <ClInclude Include="src\FileType_S.h" />
     <ClInclude Include="src\FileType_Unknown.h" />
     <ClInclude Include="src\FileType_VB.h" />

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ build/> popd
 
 ### 8.2. Windows
 
-Use Visual Studio 2019 to open the included solution file (or try `CMake`).
+Use Visual Studio 2022 to open the included solution file (or try `CMake`).
 
 ### 8.3. Additional Language Support
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,11 @@ filenames into this command. A complete commandline sample will be shown below.
 
 ### 4.2. Pre-built binaries
 
-Duplo is also available as a pre-built binary for (alpine) linux and macos. Grab
-the executable from the [releases](https://github.com/dlidstrom/Duplo/releases)
-page.
+Duplo is also available as a pre-built binary for (Alpine) Linux, macOS and 
+Windows. Grab the executable from the 
+[releases](https://github.com/dlidstrom/Duplo/releases) page.
 
-You can of course build from source as well, and you'll have to do so to get a
-binary for Windows.
+You can of course build from source as well.
 
 ## 5. Usage
 

--- a/src/Duplo.h
+++ b/src/Duplo.h
@@ -7,7 +7,11 @@
 #include <iostream>
 #include <vector>
 
+#ifdef DUPLO_VERSION
 const std::string VERSION = DUPLO_VERSION;
+#else
+const std::string VERSION = "";
+#endif
 
 namespace Duplo {
     void Run(const Options& options);

--- a/src/FileTypeBase.cpp
+++ b/src/FileTypeBase.cpp
@@ -38,7 +38,7 @@ std::vector<SourceLine> FileTypeBase::GetCleanedSourceLines(const std::vector<st
     for (std::vector<std::string>::size_type i = 0; i < lines.size(); i++) {
         auto filteredLine = GetCleanLine(lineFilter->ProcessSourceLine(lines[i]));
         if (IsSourceLine(filteredLine)) {
-            filteredLines.emplace_back(filteredLine, i);
+            filteredLines.emplace_back(filteredLine, static_cast<int>(i));
         }
     }
 

--- a/src/StringUtil.cpp
+++ b/src/StringUtil.cpp
@@ -59,7 +59,7 @@ int StringUtil::Split(const std::string& input, const std::string& delimiter, st
     }
 
     // At the beginning is always a marker
-    std::vector<int> positions(1, -sizeDelim);
+    std::vector<int> positions(1, -static_cast<int>(sizeDelim));
     auto pos = input.find(delimiter);
     while (pos != std::string::npos) {
         positions.push_back(pos);


### PR DESCRIPTION
This fixes a couple of issues that prevented the code from compiling with Visual Studio:

* `DUPLO_VERSION` is not defined in the vcxproj which makes the code not compile. I chose to make the define optional.
* Release builds with MSVC fail due to a compiler warning (treated as error).
* Updated the platform toolset version for Visual Studio 2022
* Some source and header files were missing in Duplo.vcxproj which I added.

I also took the chance of adding some tweaks and improvements to `CMakeLists.txt` so that it works with MSVC, as well.

Finally, I added Windows builds to CI.