### PR TITLE
Improve runtime by adding `seqLen` to `duplicateLines` instead of inc…

### DIFF
--- a/src/Duplo.cpp
+++ b/src/Duplo.cpp
@@ -159,7 +159,7 @@ namespace {
         return std::tuple(std::move(sourceFiles), matrix, files, locsTotal);
     }
 
-    unsigned ReportSeq(
+    void ReportSeq(
         int line1,
         int line2,
         int count,
@@ -167,7 +167,6 @@ namespace {
         const SourceFile& source1,
         const SourceFile& source2,
         std::ostream& out) {
-        unsigned duplicateLines = 0;
         if (xml) {
             out
                 << "    <set LineCount=\"" << count << "\">"
@@ -206,7 +205,6 @@ namespace {
                 StringUtil::StrSub(tmpstr, "&gt;", ">", -1);
 
                 out << "            <line Text=\"" << tmpstr << "\"/>" << std::endl;
-                duplicateLines++;
             }
 
             out << "        </lines>" << std::endl;
@@ -222,13 +220,10 @@ namespace {
                 << std::endl;
             for (int j = 0; j < count; j++) {
                 out << source1.GetLine(j + line1).GetLine() << std::endl;
-                duplicateLines++;
             }
 
             out << std::endl;
         }
-
-        return duplicateLines;
     }
 
     ProcessResult Process(
@@ -277,15 +272,15 @@ namespace {
                         int line1 = y + x - seqLen;
                         int line2 = x - seqLen;
                         if (line1 != line2 || source1 != source2) {
-                            duplicateLines +=
-                                ReportSeq(
-                                    line1,
-                                    line2,
-                                    seqLen,
-                                    options.GetOutputXml(),
-                                    source1,
-                                    source2,
-                                    outFile);
+                            ReportSeq(
+                                line1,
+                                line2,
+                                seqLen,
+                                options.GetOutputXml(),
+                                source1,
+                                source2,
+                                outFile);
+                            duplicateLines += seqLen;
                             blocks++;
                         }
                     }
@@ -298,15 +293,15 @@ namespace {
                 int line1 = m - seqLen;
                 int line2 = n - seqLen;
                 if (line1 != line2 || source1 != source2) {
-                    duplicateLines +=
-                        ReportSeq(
-                            line1,
-                            line2,
-                            seqLen,
-                            options.GetOutputXml(),
-                            source1,
-                            source2,
-                            outFile);
+                    ReportSeq(
+                        line1,
+                        line2,
+                        seqLen,
+                        options.GetOutputXml(),
+                        source1,
+                        source2,
+                        outFile);
+                    duplicateLines += seqLen;
                     blocks++;
                 }
             }
@@ -322,15 +317,15 @@ namespace {
                         seqLen++;
                     } else {
                         if (seqLen >= lMinBlockSize) {
-                            duplicateLines +=
-                                ReportSeq(
-                                    y - seqLen,
-                                    x + y - seqLen,
-                                    seqLen,
-                                    options.GetOutputXml(),
-                                    source1,
-                                    source2,
-                                    outFile);
+                            ReportSeq(
+                                y - seqLen,
+                                x + y - seqLen,
+                                seqLen,
+                                options.GetOutputXml(),
+                                source1,
+                                source2,
+                                outFile);
+                            duplicateLines += seqLen;
                             blocks++;
                         }
                         seqLen = 0;
@@ -338,15 +333,15 @@ namespace {
                 }
 
                 if (seqLen >= lMinBlockSize) {
-                    duplicateLines +=
-                        ReportSeq(
-                            m - seqLen,
-                            n - seqLen,
-                            seqLen,
-                            options.GetOutputXml(),
-                            source1,
-                            source2,
-                            outFile);
+                    ReportSeq(
+                        m - seqLen,
+                        n - seqLen,
+                        seqLen,
+                        options.GetOutputXml(),
+                        source1,
+                        source2,
+                        outFile);
+                    duplicateLines += seqLen;
                     blocks++;
                 }
             }


### PR DESCRIPTION
…rementing it by one `seqLen` times