### PR TITLE
Do not pre-compute the list of longest files

### DIFF
--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -25,6 +25,16 @@ SourceFile::SourceFile(SourceFile&& right) noexcept
     , m_sourceLines(std::move(right.m_sourceLines)) {
 }
 
+SourceFile &SourceFile::operator=(SourceFile const &other) {
+    if (this == &other) {
+        return *this;
+    }
+    m_filename = other.m_filename;
+    m_fileType = other.m_fileType;
+    m_sourceLines = other.m_sourceLines;
+    return *this;
+}
+
 size_t SourceFile::GetNumOfLines() const {
     return m_sourceLines.size();
 }

--- a/src/include/SourceFile.h
+++ b/src/include/SourceFile.h
@@ -14,6 +14,7 @@ class SourceFile {
 public:
     SourceFile(const std::string& fileName, unsigned minChars, bool ignorePrepStuff);
     SourceFile(SourceFile&& right) noexcept;
+    SourceFile &operator=(SourceFile const &other);
 
     size_t GetNumOfLines() const;
     const SourceLine& GetLine(int index) const;


### PR DESCRIPTION
Instead, compute the list of longest files only in case of an error, which is when the list is needed.

This reduces both runtime and memory for non-erroneous runs, which should be the majority of cases.