### PR TITLE
Enable more warnings (-Wextra and -pedantic) for non-MSVC compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,5 @@ find_package(nlohmann_json 3.11.3 REQUIRED)
 target_link_libraries(duplo PRIVATE nlohmann_json::nlohmann_json)
 
 if(NOT MSVC)
-    target_compile_options(duplo PRIVATE -Wall -Werror)
+    target_compile_options(duplo PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()

--- a/src/JsonExporter.cpp
+++ b/src/JsonExporter.cpp
@@ -15,10 +15,10 @@ void JsonExporter::WriteHeader() {
 }
 
 void JsonExporter::WriteFooter(
-    const Options& options,
-    int files,
-    long locsTotal,
-    const ProcessResult& processResult) {
+    const Options& /*options*/,
+    int /*files*/,
+    long /*locsTotal*/,
+    const ProcessResult& /*processResult*/) {
     Out() << m_json.dump(2);
 }
 

--- a/src/StringUtil.cpp
+++ b/src/StringUtil.cpp
@@ -8,39 +8,13 @@ namespace {
 }
 
 std::string StringUtil::Trim(const std::string& input) {
-    // If string is empty, there is nothing to look for.
-    if (input.length() == 0) {
+    auto l_idx = input.find_first_not_of(" \t");
+    if (l_idx == std::string::npos) {
         return "";
     }
 
-    // Set up temporary
-    std::string final = input;
-
-    // Remove spaces at beginning
-    decltype(input.length()) i = 0;
-    while (i < input.length() && input[i] <= ' ') {
-        i++;
-    }
-
-    // String full of spaces, return nothing.
-    if (i >= input.length()) {
-        return "";
-    }
-
-    if (i > 0) {
-        final = input.substr(i, input.length() - i);
-    }
-
-    // Remove spaces at end
-    i = final.length() - 1;
-    while (i >= 0 && final[i] <= ' ') {
-        i--;
-    }
-
-    final = final.substr(0, i + 1);
-
-    // Return the new string
-    return final;
+    auto r_idx = input.find_last_not_of(" \t");
+    return input.substr(l_idx, r_idx - l_idx + 1);
 }
 
 int StringUtil::Split(const std::string& input, const std::string& delimiter, std::vector<std::string>& results, bool doTrim) {

--- a/src/XmlExporter.cpp
+++ b/src/XmlExporter.cpp
@@ -20,10 +20,10 @@ void XmlExporter::WriteHeader() {
 }
 
 void XmlExporter::WriteFooter(
-    const Options& options,
-    int files,
-    long locsTotal,
-    const ProcessResult& processResult) {
+    const Options& /*options*/,
+    int /*files*/,
+    long /*locsTotal*/,
+    const ProcessResult& /*processResult*/) {
     Out()
         << "</duplo>"
         << std::endl;


### PR DESCRIPTION
This change also treats TAB characters at the beginning and the end of lines as whitespace, in addition to the SPACE character.