### PR TITLE
Add cmake configs for ASAN, TSAN, UBSAN and gperftools CPU Profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.15.5)
 project(duplo)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    list(APPEND CMAKE_CONFIGURATION_TYPES ASAN TSAN UBSAN PROFILE)
+    list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
+        "Add the configurations that we need"
+        FORCE)
+endif()
+
+
 file(GLOB SOURCES src/*.cpp)
 
 SET(DUPLO_VERSION "\"v1.0.1\"" CACHE STRING "Duplo version")
@@ -28,4 +38,16 @@ target_link_libraries(duplo PRIVATE nlohmann_json::nlohmann_json)
 
 if(NOT MSVC)
     target_compile_options(duplo PRIVATE -Wall -Wextra -pedantic -Werror)
+    # https://clang.llvm.org/docs/AddressSanitizer.html
+    target_compile_options(duplo PRIVATE $<$<CONFIG:ASAN>:-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -g -O1>)
+    target_link_options(duplo PRIVATE $<$<CONFIG:ASAN>:-fsanitize=address>)
+    # https://clang.llvm.org/docs/ThreadSanitizer.html
+    target_compile_options(duplo PRIVATE $<$<CONFIG:TSAN>:-fsanitize=thread -g -O1>)
+    target_link_options(duplo PRIVATE $<$<CONFIG:TSAN>:-fsanitize=thread>)
+    # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+    target_compile_options(duplo PRIVATE $<$<CONFIG:UBSAN>:-fsanitize=undefined,bounds -g -O1>)
+    target_link_options(duplo PRIVATE $<$<CONFIG:UBSAN>:-fsanitize=undefined,bounds>)
+    # gperftools CPU Profiler https://github.com/gperftools/gperftools
+    target_compile_options(duplo PRIVATE $<$<CONFIG:PROFILE>:-g -O1>)
+    target_link_options(duplo PRIVATE $<$<CONFIG:PROFILE>:-lprofiler>)
 endif()


### PR DESCRIPTION
To run the profiler, after building the `PROFILE` config, run:

```
CPUPROFILE=prof.out /path/to/build/PROFILE/duplo files.txt duplo.json
pprof --lines --web /path/to/build/PROFILE/duplo prof.out
```