### PR TITLE
feat: Added TypeScript as supported language.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Duplicated source code blocks can harm maintainability of software systems.
 Duplo is a tool to find duplicated code blocks in large code bases. Duplo has
 special support for some programming languages, meaning it can filter out
 (multi-line) comments and compiler directives. For example: C, C++, Java, C#,
-and VB.NET. Any other text format is also supported.
+VB.NET, Erlang, and TypeScript. Any other text format is also supported.
 
 ## 2. Maintainer
 
@@ -119,6 +119,8 @@ file formats:
 - VB
 - GCC assembly
 - Ada
+- Erlang (.erl, .hrl)
+- TypeScript (.ts, .tsx, .mts, .cts)
 
 This means that Duplo will remove preprocessor directives, block comments, using
 statements, etc, to only consider duplicates in actual code. In addition, Duplo
@@ -305,7 +307,6 @@ extension. Refer to [this commit](https://github.com/dlidstrom/Duplo/commit/320f
 - F#
 - Scala
 - Haskell
-- Erlang
 - What else?
 
 Send me a pull request!

--- a/src/FileTypeFactory.cpp
+++ b/src/FileTypeFactory.cpp
@@ -5,6 +5,7 @@
 #include "FileType_Erlang.h"
 #include "FileType_Java.h"
 #include "FileType_S.h"
+#include "FileType_TypeScript.h"
 #include "FileType_Unknown.h"
 #include "FileType_VB.h"
 #include "Utils.h"
@@ -27,6 +28,8 @@ IFileTypePtr FileTypeFactory::CreateFileType(
         fileType.reset(new FileType_Ada(ignorePrepStuff, minChars));
     else if (ext == "erl" || ext == "hrl")
         fileType.reset(new FileType_Erlang(ignorePrepStuff, minChars));
+    else if (ext == "ts" || ext == "tsx" || ext == "mts" || ext == "cts")
+        fileType.reset(new FileType_TypeScript(ignorePrepStuff, minChars));
     else if (ext == "java")
         fileType.reset(new FileType_Java(ignorePrepStuff, minChars));
     else

--- a/src/FileType_TypeScript.cpp
+++ b/src/FileType_TypeScript.cpp
@@ -1,0 +1,67 @@
+#include "FileType_TypeScript.h"
+#include "CstyleCommentsFilter.h"
+#include "Utils.h"
+
+#include <cctype>
+#include <cstring>
+
+namespace {
+    bool StartsWithKeyword(const std::string& line, const char* keyword) {
+        const auto length = std::strlen(keyword);
+        if (line.compare(0, length, keyword) != 0)
+            return false;
+
+        if (line.size() == length)
+            return true;
+
+        const auto next = static_cast<unsigned char>(line[length]);
+        return std::isspace(next) || line[length] == '{' || line[length] == '*';
+    }
+
+    bool StartsWithRequireCall(const std::string& line, std::string::size_type index) {
+        return line.compare(index, 8, "require(") == 0 || line.compare(index, 9, "require (") == 0;
+    }
+
+    bool IsCommonJsRequire(const std::string& line) {
+        if (StartsWithRequireCall(line, 0))
+            return true;
+
+        const char* declarations[] = { "const", "let", "var" };
+        for (auto declaration : declarations) {
+            if (!StartsWithKeyword(line, declaration))
+                continue;
+
+            const auto assignment = line.find('=');
+            if (assignment == std::string::npos)
+                return false;
+
+            const auto right = line.find_first_not_of(" \t", assignment + 1);
+            return right != std::string::npos && StartsWithRequireCall(line, right);
+        }
+
+        return false;
+    }
+}
+
+FileType_TypeScript::FileType_TypeScript(bool ignorePrepStuff, unsigned minChars)
+    : FileTypeBase(ignorePrepStuff, minChars) {
+}
+
+ILineFilterPtr FileType_TypeScript::CreateLineFilter() const {
+    return std::make_shared<CstyleCommentsLineFilter>();
+}
+
+std::string FileType_TypeScript::GetCleanLine(const std::string& line) const {
+    return CstyleUtils::RemoveSingleLineComments(line);
+}
+
+bool FileType_TypeScript::IsPreprocessorDirective(const std::string& line) const {
+    size_t first = line.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos)
+        return false;
+
+    const auto directive = line.substr(first);
+    return StartsWithKeyword(directive, "import")
+        || StartsWithKeyword(directive, "export")
+        || IsCommonJsRequire(directive);
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -52,7 +52,7 @@ namespace {
 
             std::cout << "\nDESCRIPTION\n";
             std::cout << "       Duplo is a tool to find duplicated code blocks in large\n";
-            std::cout << "       C/C++/Java/C#/VB.Net/Ada/Erlang software systems.\n\n";
+            std::cout << "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript software systems.\n\n";
 
             std::cout << "       -ml              minimal block size in lines (default is " << MIN_BLOCK_SIZE << ")\n";
             std::cout << "       -pt              percentage of lines of duplication threshold to override -ml\n";

--- a/src/include/FileType_TypeScript.h
+++ b/src/include/FileType_TypeScript.h
@@ -1,0 +1,16 @@
+#ifndef _FILETYPE_TYPESCRIPT_H_
+#define _FILETYPE_TYPESCRIPT_H_
+
+#include "FileTypeBase.h"
+
+struct FileType_TypeScript : public FileTypeBase {
+    FileType_TypeScript(bool ignorePrepStuff, unsigned minChars);
+
+    ILineFilterPtr CreateLineFilter() const override;
+
+    std::string GetCleanLine(const std::string& line) const override;
+
+    bool IsPreprocessorDirective(const std::string& line) const override;
+};
+
+#endif

--- a/tests/Simple_TypeScript/expected-ip.log
+++ b/tests/Simple_TypeScript/expected-ip.log
@@ -1,0 +1,33 @@
+Loading and hashing files ... 2 done.
+
+tests/Simple_TypeScript/simple_logger.ts(13)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(20)
+tests/Simple_TypeScript/simple_logger.ts(13)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(20)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)
+Configuration:
+  Number of files: 1
+  Minimal block size: 2
+  Minimal characters in line: 3
+  Ignore preprocessor directives: 1
+  Ignore same filenames: 0
+
+Results:
+  Lines of code: 16
+  Duplicate lines of code: 9
+  Total 3 duplicate block(s) found.
+

--- a/tests/Simple_TypeScript/expected.log
+++ b/tests/Simple_TypeScript/expected.log
@@ -1,0 +1,33 @@
+Loading and hashing files ... 2 done.
+
+tests/Simple_TypeScript/simple_logger.ts(13)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(20)
+tests/Simple_TypeScript/simple_logger.ts(13)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(20)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)
+Configuration:
+  Number of files: 1
+  Minimal block size: 2
+  Minimal characters in line: 3
+  Ignore preprocessor directives: 0
+  Ignore same filenames: 0
+
+Results:
+  Lines of code: 22
+  Duplicate lines of code: 9
+  Total 3 duplicate block(s) found.
+

--- a/tests/Simple_TypeScript/preprocessor.cts
+++ b/tests/Simple_TypeScript/preprocessor.cts
@@ -1,0 +1,6 @@
+import value from "./value";
+export { value };
+const path = require("path");
+requiredChecks();
+exportedValue();
+work();

--- a/tests/Simple_TypeScript/preprocessor.lst
+++ b/tests/Simple_TypeScript/preprocessor.lst
@@ -1,0 +1,4 @@
+tests/Simple_TypeScript/preprocessor.ts
+tests/Simple_TypeScript/preprocessor.tsx
+tests/Simple_TypeScript/preprocessor.mts
+tests/Simple_TypeScript/preprocessor.cts

--- a/tests/Simple_TypeScript/preprocessor.mts
+++ b/tests/Simple_TypeScript/preprocessor.mts
@@ -1,0 +1,6 @@
+import value from "./value";
+export { value };
+const path = require("path");
+requiredChecks();
+exportedValue();
+work();

--- a/tests/Simple_TypeScript/preprocessor.ts
+++ b/tests/Simple_TypeScript/preprocessor.ts
@@ -1,0 +1,6 @@
+import value from "./value";
+export { value };
+const path = require("path");
+requiredChecks();
+exportedValue();
+work();

--- a/tests/Simple_TypeScript/preprocessor.tsx
+++ b/tests/Simple_TypeScript/preprocessor.tsx
@@ -1,0 +1,6 @@
+import value from "./value";
+export { value };
+const path = require("path");
+requiredChecks();
+exportedValue();
+work(<span />);

--- a/tests/Simple_TypeScript/simple_logger.lst
+++ b/tests/Simple_TypeScript/simple_logger.lst
@@ -1,0 +1,1 @@
+tests/Simple_TypeScript/simple_logger.ts

--- a/tests/Simple_TypeScript/simple_logger.ts
+++ b/tests/Simple_TypeScript/simple_logger.ts
@@ -1,0 +1,30 @@
+import { format } from "./utils";
+import type { Config } from "./types";
+
+export function error(msg: string) {
+    log("ERROR", msg);
+    return true;
+    keepGoing();
+    finalize();
+}
+
+export function warning(msg: string) {
+    log("WARNING", msg);
+    return true;
+    keepGoing();
+    finalize();
+}
+
+export function info(msg: string) {
+    log("INFO", msg);
+    return true;
+    keepGoing();
+    finalize();
+}
+
+export function debug(msg: string) {
+    log("DEBUG", msg);
+    return true;
+    keepGoing();
+    finalize();
+}

--- a/tests/Simple_TypeScript/tests.bats
+++ b/tests/Simple_TypeScript/tests.bats
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+@test "simple_logger.ts" {
+    run ./build/duplo -ml 2 tests/Simple_TypeScript/simple_logger.lst out.txt
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "Loading and hashing files ... 2 done." ]
+    [ "${lines[1]}" = "tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)" ]
+}
+
+@test "simple_logger.ts out.txt" {
+    run ./build/duplo -ml 2 tests/Simple_TypeScript/simple_logger.lst -
+    [ "$status" -eq 1 ]
+    run diff <(cat tests/Simple_TypeScript/expected.log) <(./build/duplo -ml 2 tests/Simple_TypeScript/simple_logger.lst -)
+    [ "$status" -eq 0 ]
+    printf 'Lines:\n'
+    printf 'lines %s\n' "${lines[@]}" >&2
+    printf 'output %s\n' "${output[@]}" >&2
+}
+
+@test "simple_logger.ts ignores imports and exports with -ip" {
+    run diff <(cat tests/Simple_TypeScript/expected-ip.log) <(./build/duplo -ml 2 -ip tests/Simple_TypeScript/simple_logger.lst -)
+    [ "$status" -eq 0 ]
+}
+
+@test "typescript extensions use TypeScript filters" {
+    run ./build/duplo -ml 100 -ip tests/Simple_TypeScript/preprocessor.lst -
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"  Number of files: 4"* ]]
+    [[ "$output" == *"  Ignore preprocessor directives: 1"* ]]
+    [[ "$output" == *"  Lines of code: 12"* ]]
+    [[ "$output" == *"  Total 0 duplicate block(s) found."* ]]
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -10,7 +10,7 @@
     [ "${lines[3]}" = "       duplo [OPTIONS] [INPUT_FILELIST] [OUTPUT_FILE]" ]
     [ "${lines[4]}" = "DESCRIPTION" ]
     [ "${lines[5]}" = "       Duplo is a tool to find duplicated code blocks in large" ]
-    [ "${lines[6]}" = "       C/C++/Java/C#/VB.Net/Ada/Erlang software systems." ]
+    [ "${lines[6]}" = "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript software systems." ]
     [ "${lines[7]}" = "       -ml              minimal block size in lines (default is 4)" ]
     [ "${lines[8]}" = "       -pt              percentage of lines of duplication threshold to override -ml" ]
     [ "${lines[9]}" = "                        (default is 100%)" ]


### PR DESCRIPTION
## Summary

Adds TypeScript as a supported language for duplicate detection.

This includes:
- TypeScript file type detection for `.ts`, `.tsx`, `.mts`, and `.cts`
- C-style block and single-line comment filtering
- `-ip` filtering for TypeScript import/export declarations and CommonJS `require(...)`
- README and help text updates
- Bats coverage for TypeScript duplicate detection, `-ip`, and supported extensions

## Validation

- `cmake --build build`
- `bats --recursive tests`
