### PR TITLE
[Fix] Duplication not found in same file

### DIFF
--- a/src/Duplo.cpp
+++ b/src/Duplo.cpp
@@ -148,8 +148,8 @@ namespace {
             }
 
             if (seqLen >= lMinBlockSize) {
-                unsigned line1 = m - seqLen;
-                unsigned line2 = n - seqLen;
+                unsigned line1 = y + maxX - seqLen;
+                unsigned line2 = maxX - seqLen;
                 if (line1 != line2 || source1 != source2) {
                     dup_blocks.emplace_back(&source1, &source2, line1, line2, seqLen);
                     num_dup_lines += seqLen;

--- a/tests/Quake2/expected.log
+++ b/tests/Quake2/expected.log
@@ -9,7 +9,18 @@ tests/Quake2/g_chase.c(113)
 	i = ent->client->chase_target - g_edicts;
 	do {
 
-tests/Quake2/g_chase.c found: 1 block(s)
+tests/Quake2/g_chase.c(148)
+tests/Quake2/g_chase.c(124)
+		e = g_edicts + i;
+		if (!e->inuse)
+			continue;
+		if (e->solid != SOLID_NOT)
+			break;
+	} while (e != ent->client->chase_target);
+	ent->client->chase_target = e;
+	ent->client->update_chase = true;
+
+tests/Quake2/g_chase.c found: 2 block(s)
 Configuration:
   Number of files: 1
   Minimal block size: 4
@@ -19,6 +30,6 @@ Configuration:
 
 Results:
   Lines of code: 96
-  Duplicate lines of code: 6
-  Total 1 duplicate block(s) found.
+  Duplicate lines of code: 14
+  Total 2 duplicate block(s) found.
 

--- a/tests/Simple_Erlang/expected.log
+++ b/tests/Simple_Erlang/expected.log
@@ -14,6 +14,13 @@ tests/Simple_Erlang/simple_logger.erl(34)
         false ->
     end.
 
+tests/Simple_Erlang/simple_logger.erl(56)
+tests/Simple_Erlang/simple_logger.erl(45)
+        true ->
+            io:format(standard_error, "~s~n", [Message]);  
+        false ->
+    end.
+
 tests/Simple_Erlang/simple_logger.erl(45)
 tests/Simple_Erlang/simple_logger.erl(22)
         true ->
@@ -21,7 +28,21 @@ tests/Simple_Erlang/simple_logger.erl(22)
         false ->
     end.
 
-tests/Simple_Erlang/simple_logger.erl found: 3 block(s)
+tests/Simple_Erlang/simple_logger.erl(56)
+tests/Simple_Erlang/simple_logger.erl(34)
+        true ->
+            io:format(standard_error, "~s~n", [Message]);  
+        false ->
+    end.
+
+tests/Simple_Erlang/simple_logger.erl(56)
+tests/Simple_Erlang/simple_logger.erl(22)
+        true ->
+            io:format(standard_error, "~s~n", [Message]);  
+        false ->
+    end.
+
+tests/Simple_Erlang/simple_logger.erl found: 6 block(s)
 Configuration:
   Number of files: 1
   Minimal block size: 2
@@ -31,6 +52,6 @@ Configuration:
 
 Results:
   Lines of code: 42
-  Duplicate lines of code: 12
-  Total 3 duplicate block(s) found.
+  Duplicate lines of code: 24
+  Total 6 duplicate block(s) found.
 

--- a/tests/Simple_Erlang/tests.bats
+++ b/tests/Simple_Erlang/tests.bats
@@ -4,7 +4,7 @@
     run ./build/duplo -ml 2 tests/Simple_Erlang/simple_logger.lst out.txt
     [ "$status" -eq 1 ]
     [ "${lines[0]}" = "Loading and hashing files ... 2 done." ]
-    [ "${lines[1]}" = "tests/Simple_Erlang/simple_logger.erl found: 3 block(s)" ]
+    [ "${lines[1]}" = "tests/Simple_Erlang/simple_logger.erl found: 6 block(s)" ]
 }
 
 @test "simple_logger.erl out.txt" {

--- a/tests/Simple_TypeScript/expected-ip.log
+++ b/tests/Simple_TypeScript/expected-ip.log
@@ -12,13 +12,31 @@ tests/Simple_TypeScript/simple_logger.ts(13)
     keepGoing();
     finalize();
 
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(20)
+    return true;
+    keepGoing();
+    finalize();
+
 tests/Simple_TypeScript/simple_logger.ts(20)
 tests/Simple_TypeScript/simple_logger.ts(6)
     return true;
     keepGoing();
     finalize();
 
-tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(13)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts found: 6 block(s)
 Configuration:
   Number of files: 1
   Minimal block size: 2
@@ -28,6 +46,6 @@ Configuration:
 
 Results:
   Lines of code: 16
-  Duplicate lines of code: 9
-  Total 3 duplicate block(s) found.
+  Duplicate lines of code: 18
+  Total 6 duplicate block(s) found.
 

--- a/tests/Simple_TypeScript/expected.log
+++ b/tests/Simple_TypeScript/expected.log
@@ -12,13 +12,31 @@ tests/Simple_TypeScript/simple_logger.ts(13)
     keepGoing();
     finalize();
 
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(20)
+    return true;
+    keepGoing();
+    finalize();
+
 tests/Simple_TypeScript/simple_logger.ts(20)
 tests/Simple_TypeScript/simple_logger.ts(6)
     return true;
     keepGoing();
     finalize();
 
-tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(13)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts(27)
+tests/Simple_TypeScript/simple_logger.ts(6)
+    return true;
+    keepGoing();
+    finalize();
+
+tests/Simple_TypeScript/simple_logger.ts found: 6 block(s)
 Configuration:
   Number of files: 1
   Minimal block size: 2
@@ -28,6 +46,6 @@ Configuration:
 
 Results:
   Lines of code: 22
-  Duplicate lines of code: 9
-  Total 3 duplicate block(s) found.
+  Duplicate lines of code: 18
+  Total 6 duplicate block(s) found.
 

--- a/tests/Simple_TypeScript/tests.bats
+++ b/tests/Simple_TypeScript/tests.bats
@@ -4,7 +4,7 @@
     run ./build/duplo -ml 2 tests/Simple_TypeScript/simple_logger.lst out.txt
     [ "$status" -eq 1 ]
     [ "${lines[0]}" = "Loading and hashing files ... 2 done." ]
-    [ "${lines[1]}" = "tests/Simple_TypeScript/simple_logger.ts found: 3 block(s)" ]
+    [ "${lines[1]}" = "tests/Simple_TypeScript/simple_logger.ts found: 6 block(s)" ]
 }
 
 @test "simple_logger.ts out.txt" {


### PR DESCRIPTION
When comparing 2 segments of the same file, `m == n` and thus `line1 == line2` which terminated at EOF and was discarded due to self-match.
```
unsigned line1 = m - seqLen;
unsigned line2 = n - seqLen;
```

Using the variables `y` and `maxX` to calculate the line-numbers, yields non-identical lines, which can be checked for duplicates.
```
unsigned line1 = y + maxX - seqLen;
unsigned line2 = maxX - seqLen;
```

Test cases have been adjusted to check for multiple duplicate blocks within the same file.