### PR TITLE
[Feat] Add Swift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ file formats:
 - Ada
 - Erlang (.erl, .hrl)
 - TypeScript (.ts, .tsx, .mts, .cts)
+- Swift (.swift)
 
 This means that Duplo will remove preprocessor directives, block comments, using
 statements, etc, to only consider duplicates in actual code. In addition, Duplo

--- a/src/FileTypeFactory.cpp
+++ b/src/FileTypeFactory.cpp
@@ -5,6 +5,7 @@
 #include "FileType_Erlang.h"
 #include "FileType_Java.h"
 #include "FileType_S.h"
+#include "FileType_Swift.h"
 #include "FileType_TypeScript.h"
 #include "FileType_Unknown.h"
 #include "FileType_VB.h"
@@ -32,6 +33,8 @@ IFileTypePtr FileTypeFactory::CreateFileType(
         fileType.reset(new FileType_TypeScript(ignorePrepStuff, minChars));
     else if (ext == "java")
         fileType.reset(new FileType_Java(ignorePrepStuff, minChars));
+    else if (ext == "swift")
+        fileType.reset(new FileType_Swift(ignorePrepStuff, minChars));
     else
         fileType.reset(new FileType_Unknown(minChars));
     return fileType;

--- a/src/FileType_Swift.cpp
+++ b/src/FileType_Swift.cpp
@@ -1,0 +1,44 @@
+#include "FileType_Swift.h"
+#include "CstyleCommentsFilter.h"
+#include "Utils.h"
+
+#include <cctype>
+#include <cstring>
+
+namespace {
+    bool StartsWithKeyword(const std::string& line, const char* keyword) {
+        const auto length = std::strlen(keyword);
+        if (line.compare(0, length, keyword) != 0)
+            return false;
+
+        if (line.size() == length)
+            return true;
+
+        const auto next = static_cast<unsigned char>(line[length]);
+        return std::isspace(next) || line[length] == '{' || line[length] == '*';
+    }
+}
+
+FileType_Swift::FileType_Swift(bool ignorePrepStuff, unsigned minChars)
+    : FileTypeBase(ignorePrepStuff, minChars) {
+}
+
+ILineFilterPtr FileType_Swift::CreateLineFilter() const {
+    return std::make_shared<CstyleCommentsLineFilter>();
+}
+
+std::string FileType_Swift::GetCleanLine(const std::string& line) const {
+    return CstyleUtils::RemoveSingleLineComments(line);
+}
+
+bool FileType_Swift::IsPreprocessorDirective(const std::string& line) const {
+    size_t first = line.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos)
+        return false;
+
+    // Swift compiler control statements (#if, #available, #selector, ...)
+    if (line[first] == '#')
+        return true;
+
+    return StartsWithKeyword(line.substr(first), "import");
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -52,7 +52,7 @@ namespace {
 
             std::cout << "\nDESCRIPTION\n";
             std::cout << "       Duplo is a tool to find duplicated code blocks in large\n";
-            std::cout << "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript software systems.\n\n";
+            std::cout << "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript/Swift software systems.\n\n";
 
             std::cout << "       -ml              minimal block size in lines (default is " << MIN_BLOCK_SIZE << ")\n";
             std::cout << "       -pt              percentage of lines of duplication threshold to override -ml\n";

--- a/src/include/FileType_Swift.h
+++ b/src/include/FileType_Swift.h
@@ -1,0 +1,16 @@
+#ifndef _FILETYPE_Swift_H_
+#define _FILETYPE_Swift_H_
+
+#include "FileTypeBase.h"
+
+struct FileType_Swift : public FileTypeBase {
+    FileType_Swift(bool ignorePrepStuff, unsigned minChars);
+
+    ILineFilterPtr CreateLineFilter() const override;
+
+    std::string GetCleanLine(const std::string& line) const override;
+
+    bool IsPreprocessorDirective(const std::string& line) const override;
+};
+
+#endif

--- a/tests/Simple_Swift/expected-ip.log
+++ b/tests/Simple_Swift/expected-ip.log
@@ -1,0 +1,33 @@
+Loading and hashing files ... 2 done.
+
+tests/Simple_Swift/simple_logger.swift(15)
+tests/Simple_Swift/simple_logger.swift(6)
+    finalize()
+    keepGoing()
+    cleanup()
+
+tests/Simple_Swift/simple_logger.swift(22)
+tests/Simple_Swift/simple_logger.swift(15)
+    finalize()
+    keepGoing()
+    cleanup()
+
+tests/Simple_Swift/simple_logger.swift(22)
+tests/Simple_Swift/simple_logger.swift(6)
+    finalize()
+    keepGoing()
+    cleanup()
+
+tests/Simple_Swift/simple_logger.swift found: 3 block(s)
+Configuration:
+  Number of files: 1
+  Minimal block size: 2
+  Minimal characters in line: 3
+  Ignore preprocessor directives: 1
+  Ignore same filenames: 0
+
+Results:
+  Lines of code: 15
+  Duplicate lines of code: 9
+  Total 3 duplicate block(s) found.
+

--- a/tests/Simple_Swift/expected.log
+++ b/tests/Simple_Swift/expected.log
@@ -1,0 +1,21 @@
+Loading and hashing files ... 2 done.
+
+tests/Simple_Swift/simple_logger.swift(22)
+tests/Simple_Swift/simple_logger.swift(15)
+    finalize()
+    keepGoing()
+    cleanup()
+
+tests/Simple_Swift/simple_logger.swift found: 1 block(s)
+Configuration:
+  Number of files: 1
+  Minimal block size: 2
+  Minimal characters in line: 3
+  Ignore preprocessor directives: 0
+  Ignore same filenames: 0
+
+Results:
+  Lines of code: 18
+  Duplicate lines of code: 3
+  Total 1 duplicate block(s) found.
+

--- a/tests/Simple_Swift/simple_logger.lst
+++ b/tests/Simple_Swift/simple_logger.lst
@@ -1,0 +1,1 @@
+tests/Simple_Swift/simple_logger.swift

--- a/tests/Simple_Swift/simple_logger.swift
+++ b/tests/Simple_Swift/simple_logger.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+func error(_ msg: String) {
+    /* report the error */
+    log("ERROR", msg)  // inline note
+    finalize()
+#if DEBUG
+    keepGoing()
+#endif
+    cleanup()
+}
+
+func warning(_ msg: String) {
+    log("WARNING", msg)
+    finalize()
+    keepGoing()
+    cleanup()
+}
+
+func info(_ msg: String) {
+    log("INFO", msg)
+    finalize()
+    keepGoing()
+    cleanup()
+}

--- a/tests/Simple_Swift/tests.bats
+++ b/tests/Simple_Swift/tests.bats
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+@test "simple_logger.swift" {
+    run ./build/duplo -ml 2 tests/Simple_Swift/simple_logger.lst out.txt
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "Loading and hashing files ... 2 done." ]
+    [ "${lines[1]}" = "tests/Simple_Swift/simple_logger.swift found: 1 block(s)" ]
+}
+
+@test "simple_logger.swift out.txt" {
+    run ./build/duplo -ml 2 tests/Simple_Swift/simple_logger.lst -
+    [ "$status" -eq 1 ]
+    run diff <(cat tests/Simple_Swift/expected.log) <(./build/duplo -ml 2 tests/Simple_Swift/simple_logger.lst -)
+    [ "$status" -eq 0 ]
+}
+
+@test "simple_logger.swift ignores imports and compiler directives with -ip" {
+    run diff <(cat tests/Simple_Swift/expected-ip.log) <(./build/duplo -ml 2 -ip tests/Simple_Swift/simple_logger.lst -)
+    [ "$status" -eq 0 ]
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -10,7 +10,7 @@
     [ "${lines[3]}" = "       duplo [OPTIONS] [INPUT_FILELIST] [OUTPUT_FILE]" ]
     [ "${lines[4]}" = "DESCRIPTION" ]
     [ "${lines[5]}" = "       Duplo is a tool to find duplicated code blocks in large" ]
-    [ "${lines[6]}" = "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript software systems." ]
+    [ "${lines[6]}" = "       C/C++/Java/C#/VB.Net/Ada/Erlang/TypeScript/Swift software systems." ]
     [ "${lines[7]}" = "       -ml              minimal block size in lines (default is 4)" ]
     [ "${lines[8]}" = "       -pt              percentage of lines of duplication threshold to override -ml" ]
     [ "${lines[9]}" = "                        (default is 100%)" ]


### PR DESCRIPTION
Uses C-Comments and defines preprocessor directives starting with `#` and `import`.

Test cases already follow the proposed fix in #95  